### PR TITLE
Story 1871 update to OZP Webtop

### DIFF
--- a/src/app/services/widget.services.js
+++ b/src/app/services/widget.services.js
@@ -134,8 +134,8 @@ var widgets = angular.module('ozpWebtop.services.widgets',[
         var zIndex = 0;
         var top = 75;
         var left = 75;
-        var width = 250;
-        var height = 250;
+        var width = 500;
+        var height = 500;
 
         var MaxArray = [];
         MaxArray.max =  function(){


### PR DESCRIPTION
Changed default widget size from 250x250 to 500x500 as per ticket 1871 of OZP Platform project. This will increase usability of widgets right out of the box instead of making the user resize before use.